### PR TITLE
fix(ci): skip RG lock creation in deployment (managed out-of-band)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -133,7 +133,7 @@ jobs:
             --resource-group $RESOURCE_GROUP \
             --template-file infra/main.bicep \
             --only-show-errors \
-            --parameters appName=$APP_NAME createRoleAssignment=false \
+            --parameters appName=$APP_NAME createRoleAssignment=false enableResourceGroupLock=false \
               submissionTokenSecret="$SUBMISSION_TOKEN_SECRET" \
               googleClientId="$GOOGLE_CLIENT_ID" \
               googleClientSecret="$GOOGLE_CLIENT_SECRET" \
@@ -265,7 +265,7 @@ jobs:
             --resource-group $RESOURCE_GROUP \
             --template-file infra/main.bicep \
             --only-show-errors \
-            --parameters appName=$APP_NAME createRoleAssignment=false \
+            --parameters appName=$APP_NAME createRoleAssignment=false enableResourceGroupLock=false \
               imageTag="${{ github.sha }}" \
               submissionTokenSecret="$SUBMISSION_TOKEN_SECRET" \
               googleClientId="$GOOGLE_CLIENT_ID" \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -566,9 +566,20 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
 // CanNotDelete prevents accidental teardown of the entire resource group
 // (the most common cause of total outage in single-RG apps). Reads and
 // updates remain unrestricted, so CI/CD continues to function normally.
+//
+// Locks require Microsoft.Authorization/locks/write permission, which the
+// CI service principal (Contributor) does NOT have. Same pattern as
+// createRoleAssignment: apply once manually with the command below, then
+// pass enableResourceGroupLock=false in CI so the deployment skips this
+// resource on subsequent runs.
+//
+//   az lock create --name protect-rg --resource-group rg-svensktkorsord \
+//                  --lock-type CanNotDelete \
+//                  --notes "Production resource group..."
+//
 // To remove the lock for an intentional teardown:
-//   az lock delete -n protect-rg -g rg-svensktkorsord --resource-group
-@description('Apply a CanNotDelete lock on the resource group. Disable only for intentional teardown.')
+//   az lock delete --name protect-rg --resource-group rg-svensktkorsord
+@description('Apply a CanNotDelete lock on the resource group via this template. Requires Owner or User Access Administrator. Set to false in CI; apply the lock once manually with `az lock create` instead.')
 param enableResourceGroupLock bool = true
 
 resource rgLock 'Microsoft.Authorization/locks@2020-05-01' = if (enableResourceGroupLock) {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "4749877708959361997"
+      "templateHash": "7334638629172616923"
     }
   },
   "parameters": {
@@ -113,7 +113,7 @@
       "type": "bool",
       "defaultValue": true,
       "metadata": {
-        "description": "Apply a CanNotDelete lock on the resource group. Disable only for intentional teardown."
+        "description": "Apply a CanNotDelete lock on the resource group via this template. Requires Owner or User Access Administrator. Set to false in CI; apply the lock once manually with `az lock create` instead."
       }
     }
   },


### PR DESCRIPTION
CI service principal lacks Microsoft.Authorization/locks/write. Apply the lock once manually via 'az lock create' (same pattern as createRoleAssignment), then pass enableResourceGroupLock=false in CI. Bicep param description updated.