### PR TITLE
fix(infra): drop LTR policy (incompatible with serverless auto-pause)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -338,19 +338,22 @@ resource sqlPitrPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetention
   }
 }
 
-// Long-term retention: 4 weekly + 12 monthly + 7 yearly backups in archive
-// storage. Yearly snapshot is taken from the week-1 weekly backup. Cost is
-// roughly $0.05/GB/month — pennies for a sub-2 GB OLTP database.
-resource sqlLtrPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-08-01-preview' = if (deployDatabase) {
-  parent: sqlDb
-  name: 'default'
-  properties: {
-    weeklyRetention: 'P4W'
-    monthlyRetention: 'P12M'
-    yearlyRetention: 'P7Y'
-    weekOfYear: 1
-  }
-}
+// Long-term retention is intentionally NOT configured here.
+// Azure rejects LTR on serverless databases with auto-pause enabled
+// (LtrConfigPolicyUnsupportedIfAutoPauseEnabled), and the Free tier forces
+// auto-pause on. Re-enable LTR if/when this DB is migrated to a paid tier
+// without auto-pause:
+//
+//   resource sqlLtrPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-08-01-preview' = if (deployDatabase) {
+//     parent: sqlDb
+//     name: 'default'
+//     properties: {
+//       weeklyRetention: 'P4W'
+//       monthlyRetention: 'P12M'
+//       yearlyRetention: 'P7Y'
+//       weekOfYear: 1
+//     }
+//   }
 
 // Connection Timeout=60 gives the serverless DB time to resume from auto-pause
 // (cold-start typically takes 30–60s). ConnectRetryCount/Interval cover broken

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "7334638629172616923"
+      "templateHash": "14887267863255158524"
     }
   },
   "parameters": {
@@ -398,21 +398,6 @@
       "properties": {
         "retentionDays": 35,
         "diffBackupIntervalInHours": 24
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers/databases', take(variables('sqlServerName'), 63), variables('sqlDbName'))]"
-      ]
-    },
-    {
-      "condition": "[parameters('deployDatabase')]",
-      "type": "Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies",
-      "apiVersion": "2023-08-01-preview",
-      "name": "[format('{0}/{1}/{2}', take(variables('sqlServerName'), 63), variables('sqlDbName'), 'default')]",
-      "properties": {
-        "weeklyRetention": "P4W",
-        "monthlyRetention": "P12M",
-        "yearlyRetention": "P7Y",
-        "weekOfYear": 1
       },
       "dependsOn": [
         "[resourceId('Microsoft.Sql/servers/databases', take(variables('sqlServerName'), 63), variables('sqlDbName'))]"


### PR DESCRIPTION
Free-tier serverless SQL forces auto-pause on, and Azure rejects LTR on auto-paused serverless DBs (LtrConfigPolicyUnsupportedIfAutoPauseEnabled). Keep PITR (35d) which is the most important DR coverage; document re-enabling LTR if/when migrated to a paid non-serverless tier.