### PR TITLE
infra: narrow SQL firewall to Container App env IP

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -129,11 +129,23 @@ jobs:
           ADMIN_USER_IDS: ${{ secrets.ADMIN_USER_IDS }}
         run: |
           set -euo pipefail
+          # Discover the Container Apps environment static outbound IP if the
+          # environment already exists. On a brand-new deploy this returns
+          # empty, which Bicep handles by skipping the firewall rule on the
+          # first pass; the second deploy run will pin it.
+          ENV_IP=$(az containerapp env show \
+            --resource-group $RESOURCE_GROUP \
+            --name ${APP_NAME}-env \
+            --query properties.staticIp \
+            --output tsv 2>/dev/null || echo '')
+          echo "Container App env outbound IP: ${ENV_IP:-<not yet provisioned>}"
+
           RESULT=$(az deployment group create \
             --resource-group $RESOURCE_GROUP \
             --template-file infra/main.bicep \
             --only-show-errors \
             --parameters appName=$APP_NAME createRoleAssignment=false enableResourceGroupLock=false \
+              containerAppOutboundIp="$ENV_IP" \
               submissionTokenSecret="$SUBMISSION_TOKEN_SECRET" \
               googleClientId="$GOOGLE_CLIENT_ID" \
               googleClientSecret="$GOOGLE_CLIENT_SECRET" \
@@ -261,11 +273,19 @@ jobs:
           ADMIN_USER_IDS: ${{ secrets.ADMIN_USER_IDS }}
         run: |
           set -euo pipefail
+          ENV_IP=$(az containerapp env show \
+            --resource-group $RESOURCE_GROUP \
+            --name ${APP_NAME}-env \
+            --query properties.staticIp \
+            --output tsv 2>/dev/null || echo '')
+          echo "Container App env outbound IP: ${ENV_IP:-<not yet provisioned>}"
+
           az deployment group create \
             --resource-group $RESOURCE_GROUP \
             --template-file infra/main.bicep \
             --only-show-errors \
             --parameters appName=$APP_NAME createRoleAssignment=false enableResourceGroupLock=false \
+              containerAppOutboundIp="$ENV_IP" \
               imageTag="${{ github.sha }}" \
               submissionTokenSecret="$SUBMISSION_TOKEN_SECRET" \
               googleClientId="$GOOGLE_CLIENT_ID" \

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -55,6 +55,12 @@ param adminUserIds string = ''
 @description('Deploy Azure SQL resources. Set to true when SQL is needed.')
 param deployDatabase bool = true
 
+@description('Container Apps environment static outbound IP. Pin the SQL firewall to this single address. Get with: az containerapp env show -g <rg> -n <env> --query properties.staticIp -o tsv. Leave empty to skip the firewall rule (e.g. on a brand-new deploy where the env does not yet exist).')
+param containerAppOutboundIp string = ''
+
+@description('Optional developer workstation IP for ad-hoc DB access (migrations, hot-fixes, debugging). Get with: (Invoke-RestMethod ifconfig.me/ip).Trim(). Leave empty in CI.')
+param developerWorkstationIp string = ''
+
 @description('Create role assignments (AcrPull on ACR + Key Vault Secrets User on the Key Vault) for the managed identity. Set to true for first-time manual deploy AND any time new role-assignment-bearing resources are added (e.g. when Key Vault was introduced). Set to false for CI/CD which typically lacks Owner / User Access Administrator. If CI/CD reports "Unable to get value using Managed identity ... unable to fetch secret", run a manual deploy once with createRoleAssignment=true (or grant the Key Vault Secrets User role to the managed identity manually) and then re-run CI/CD.')
 param createRoleAssignment bool = true
 
@@ -294,13 +300,31 @@ resource sqlAadOnlyAuth 'Microsoft.Sql/servers/azureADOnlyAuthentications@2023-0
   }
 }
 
-// Allow Azure services (Container Apps) to connect
-resource sqlFirewallAllowAzure 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = if (deployDatabase) {
+// Firewall: narrow allowlist instead of the magic 0.0.0.0 rule. The previous
+// 'AllowAllAzureIps' rule permitted connection attempts from every Azure
+// customer's outbound IP space. We now restrict to:
+//   1) The Container Apps environment's static outbound IP (the one client
+//      that actually needs to reach the DB).
+//   2) Optional developer workstation IP for ad-hoc admin access.
+//
+// Auth is still Entra-only (no SQL passwords), so even if the firewall is
+// bypassed via subnet spoofing the attacker still needs a valid managed
+// identity token. This is defense-in-depth.
+resource sqlFirewallContainerApp 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = if (deployDatabase && containerAppOutboundIp != '') {
   parent: sqlServer
-  name: 'AllowAllAzureIps'
+  name: 'AllowContainerAppEnv'
   properties: {
-    startIpAddress: '0.0.0.0'
-    endIpAddress: '0.0.0.0'
+    startIpAddress: containerAppOutboundIp
+    endIpAddress: containerAppOutboundIp
+  }
+}
+
+resource sqlFirewallDev 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = if (deployDatabase && developerWorkstationIp != '') {
+  parent: sqlServer
+  name: 'AllowDeveloperWorkstation'
+  properties: {
+    startIpAddress: developerWorkstationIp
+    endIpAddress: developerWorkstationIp
   }
 }
 

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "14887267863255158524"
+      "templateHash": "6275412043056884271"
     }
   },
   "parameters": {
@@ -79,6 +79,20 @@
       "defaultValue": true,
       "metadata": {
         "description": "Deploy Azure SQL resources. Set to true when SQL is needed."
+      }
+    },
+    "containerAppOutboundIp": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Container Apps environment static outbound IP. Pin the SQL firewall to this single address. Get with: az containerapp env show -g <rg> -n <env> --query properties.staticIp -o tsv. Leave empty to skip the firewall rule (e.g. on a brand-new deploy where the env does not yet exist)."
+      }
+    },
+    "developerWorkstationIp": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional developer workstation IP for ad-hoc DB access (migrations, hot-fixes, debugging). Get with: (Invoke-RestMethod ifconfig.me/ip).Trim(). Leave empty in CI."
       }
     },
     "createRoleAssignment": {
@@ -357,13 +371,26 @@
       ]
     },
     {
-      "condition": "[parameters('deployDatabase')]",
+      "condition": "[and(parameters('deployDatabase'), not(equals(parameters('containerAppOutboundIp'), '')))]",
       "type": "Microsoft.Sql/servers/firewallRules",
       "apiVersion": "2023-08-01-preview",
-      "name": "[format('{0}/{1}', take(variables('sqlServerName'), 63), 'AllowAllAzureIps')]",
+      "name": "[format('{0}/{1}', take(variables('sqlServerName'), 63), 'AllowContainerAppEnv')]",
       "properties": {
-        "startIpAddress": "0.0.0.0",
-        "endIpAddress": "0.0.0.0"
+        "startIpAddress": "[parameters('containerAppOutboundIp')]",
+        "endIpAddress": "[parameters('containerAppOutboundIp')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63))]"
+      ]
+    },
+    {
+      "condition": "[and(parameters('deployDatabase'), not(equals(parameters('developerWorkstationIp'), '')))]",
+      "type": "Microsoft.Sql/servers/firewallRules",
+      "apiVersion": "2023-08-01-preview",
+      "name": "[format('{0}/{1}', take(variables('sqlServerName'), 63), 'AllowDeveloperWorkstation')]",
+      "properties": {
+        "startIpAddress": "[parameters('developerWorkstationIp')]",
+        "endIpAddress": "[parameters('developerWorkstationIp')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63))]"


### PR DESCRIPTION
Replace catch-all AllowAllAzureIps (0.0.0.0) with explicit allowlist:
 - Container App env outbound IP (queried at deploy time, self-healing).
 - Optional developer workstation IP (empty by default). Defense-in-depth on top of existing Entra-only auth.