### PR TITLE
Update managed identity name to include unique suffix

### DIFF
--- a/scripts/setup-sql-user.ps1
+++ b/scripts/setup-sql-user.ps1
@@ -83,7 +83,7 @@ $currentUser = az ad signed-in-user show `
 if (-not $UserEmail) { $UserEmail = $currentUser.upn }
 Write-Host "  User to add: $UserEmail"
 
-$identityName = "$AppName-identity"
+$identityName = "$AppName-identity-eac35eg3j6fyw"
 $miJson = az identity show `
     --resource-group $ResourceGroup `
     --name $identityName `


### PR DESCRIPTION
Changed $identityName  to  in setup-sql-user.ps1 to ensure a more specific and unique managed identity is used in Azure CLI operations.