### PR TITLE
Switch to always-on Azure SQL S0, improve OIDC workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# Copilot Instructions
+
+## Project Guidelines
+- User prefers not to use Azure SQL auto-pause because it harms user experience; favor always-on database options for this app.

--- a/.github/workflows/test-azure-oidc.yml
+++ b/.github/workflows/test-azure-oidc.yml
@@ -16,7 +16,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Check Azure OIDC secrets
+        id: secret-check
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.AZURE_CLIENT_ID }}" ] && \
+             [ -n "${{ secrets.AZURE_TENANT_ID }}" ] && \
+             [ -n "${{ secrets.AZURE_SUBSCRIPTION_ID }}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip OIDC login test when Azure secrets are unavailable
+        if: steps.secret-check.outputs.available != 'true'
+        run: |
+          echo "::notice::Skipping Azure OIDC login test. Required secrets are unavailable for this event actor."
+
       - name: Azure Login (OIDC)
+        if: steps.secret-check.outputs.available == 'true'
         uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -24,6 +42,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Select subscription (if provided)
+        if: steps.secret-check.outputs.available == 'true'
         run: |
           if [ -n "${{ secrets.AZURE_SUBSCRIPTION_ID }}" ]; then
             az account set --subscription "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
@@ -33,9 +52,12 @@ jobs:
           fi
 
       - name: Confirm identity and account
+        if: steps.secret-check.outputs.available == 'true'
         run: |
           az account show
           az ad signed-in-user show || true
 
       - name: Smoke test - list resource groups
+        if: steps.secret-check.outputs.available == 'true'
         run: az group list -o table || true
+

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -274,7 +274,7 @@ resource fileShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-0
 }
 
 // ---------------------------------------------------------------------------
-// Azure SQL Server + Free tier database (Entra-only authentication)
+// Azure SQL Server + DTU Standard S0 database (Entra-only authentication)
 // ---------------------------------------------------------------------------
 resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = if (deployDatabase) {
   name: take(sqlServerName, 63)
@@ -335,26 +335,18 @@ resource sqlDb 'Microsoft.Sql/servers/databases@2023-08-01-preview' = if (deploy
   name: sqlDbName
   location: location
   sku: {
-    name: 'GP_S_Gen5_2'
-    tier: 'GeneralPurpose'
+    name: 'S0'
+    tier: 'Standard'
   }
   properties: {
     collation: 'SQL_Latin1_General_CP1_CI_AS'
-    maxSizeBytes: 34359738368 // 32 GB (free tier limit)
-    // autoPauseDelay omitted: Free Limit databases require the default
-    // auto-pause delay (60 min) and reject custom values.
-    minCapacity: json('0.5')
-    useFreeLimit: true
-    // BillOverUsage keeps the database online once the monthly free
-    // vCore-second quota (~100k s) is exhausted, billing per-second over the
-    // free allowance instead of pausing the DB until the next month. The
-    // 60-min idle auto-pause still applies, so cost stays near zero when idle.
-    freeLimitExhaustionBehavior: 'BillOverUsage'
+    maxSizeBytes: 268435456000 // 250 GB included with Standard S0
   }
 }
 
-// Point-in-time restore window: 35 days (the maximum, free of charge for the
-// underlying differential backups; only outbound restore costs apply).
+// Point-in-time restore window: 35 days (the maximum supported for this app's
+// short-term recovery needs). Existing backups remain local redundant unless you
+// later choose a different redundancy option.
 resource sqlPitrPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetentionPolicies@2023-08-01-preview' = if (deployDatabase) {
   parent: sqlDb
   name: 'default'
@@ -364,11 +356,9 @@ resource sqlPitrPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetention
   }
 }
 
-// Long-term retention is intentionally NOT configured here.
-// Azure rejects LTR on serverless databases with auto-pause enabled
-// (LtrConfigPolicyUnsupportedIfAutoPauseEnabled), and the Free tier forces
-// auto-pause on. Re-enable LTR if/when this DB is migrated to a paid tier
-// without auto-pause:
+// Long-term retention is intentionally not configured here to keep backup
+// costs and retention sprawl low for this app. Re-enable it later only if you
+// need compliance-style archival restores.
 //
 //   resource sqlLtrPolicy 'Microsoft.Sql/servers/databases/backupLongTermRetentionPolicies@2023-08-01-preview' = if (deployDatabase) {
 //     parent: sqlDb
@@ -381,9 +371,9 @@ resource sqlPitrPolicy 'Microsoft.Sql/servers/databases/backupShortTermRetention
 //     }
 //   }
 
-// Connection Timeout=60 gives the serverless DB time to resume from auto-pause
-// (cold-start typically takes 30–60s). ConnectRetryCount/Interval cover broken
-// connections after login; initial-login retries are handled in code.
+// Connection Timeout=60 and SqlClient connect retries provide extra headroom
+// for transient network events and scale operations even though this DTU tier
+// no longer relies on serverless auto-pause/resume.
 var sqlConnectionString = deployDatabase ? 'Server=tcp:${sqlServer!.properties.fullyQualifiedDomainName},1433;Database=${sqlDbName};Authentication=Active Directory Managed Identity;User Id=${identity.properties.clientId};Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;ConnectRetryCount=10;ConnectRetryInterval=10;' : ''
 
 // ---------------------------------------------------------------------------

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "6275412043056884271"
+      "templateHash": "402480203261687648"
     }
   },
   "parameters": {
@@ -172,7 +172,7 @@
     {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
       "apiVersion": "2023-01-31",
-      "name": "[format('{0}-identity', parameters('appName'))]",
+      "name": "[format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))]",
       "location": "[parameters('location')]"
     },
     {
@@ -180,15 +180,15 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
       "scope": "[resourceId('Microsoft.ContainerRegistry/registries', take(variables('acrNameFinal'), 50))]",
-      "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', take(variables('acrNameFinal'), 50)), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), variables('acrPullRoleId'))]",
+      "name": "[guid(resourceId('Microsoft.ContainerRegistry/registries', take(variables('acrNameFinal'), 50)), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), variables('acrPullRoleId'))]",
       "properties": {
-        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), '2023-01-31').principalId]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), '2023-01-31').principalId]",
         "principalType": "ServicePrincipal",
         "roleDefinitionId": "[variables('acrPullRoleId')]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.ContainerRegistry/registries', take(variables('acrNameFinal'), 50))]",
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))]"
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))]"
       ]
     },
     {
@@ -214,14 +214,14 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2022-04-01",
       "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('kvName'))]",
-      "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), variables('kvSecretsUserRoleId'))]",
+      "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), variables('kvSecretsUserRoleId'))]",
       "properties": {
-        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), '2023-01-31').principalId]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), '2023-01-31').principalId]",
         "principalType": "ServicePrincipal",
         "roleDefinitionId": "[variables('kvSecretsUserRoleId')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))]",
         "[resourceId('Microsoft.KeyVault/vaults', variables('kvName'))]"
       ]
     },
@@ -348,14 +348,14 @@
         "publicNetworkAccess": "Enabled",
         "administrators": {
           "administratorType": "ActiveDirectory",
-          "login": "[format('{0}-identity', parameters('appName'))]",
-          "sid": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), '2023-01-31').principalId]",
+          "login": "[format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))]",
+          "sid": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), '2023-01-31').principalId]",
           "tenantId": "[tenant().tenantId]",
           "principalType": "Application"
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))]"
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))]"
       ]
     },
     {
@@ -403,15 +403,12 @@
       "name": "[format('{0}/{1}', take(variables('sqlServerName'), 63), variables('sqlDbName'))]",
       "location": "[parameters('location')]",
       "sku": {
-        "name": "GP_S_Gen5_2",
-        "tier": "GeneralPurpose"
+        "name": "S0",
+        "tier": "Standard"
       },
       "properties": {
         "collation": "SQL_Latin1_General_CP1_CI_AS",
-        "maxSizeBytes": 34359738368,
-        "minCapacity": "[json('0.5')]",
-        "useFreeLimit": true,
-        "freeLimitExhaustionBehavior": "BillOverUsage"
+        "maxSizeBytes": 268435456000
       },
       "dependsOn": [
         "[resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63))]"
@@ -474,7 +471,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))))]": {}
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))))]": {}
         }
       },
       "properties": {
@@ -486,11 +483,11 @@
             "transport": "auto",
             "allowInsecure": false
           },
-          "secrets": "[union(if(parameters('hasSubmissionTokenSecret'), createArray(createObject('name', 'submissiontoken-secret', 'keyVaultUrl', format('{0}secrets/submissiontoken-secret', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))))), createArray()), if(parameters('hasGoogleAuth'), createArray(createObject('name', 'google-client-id', 'keyVaultUrl', format('{0}secrets/google-client-id', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))), createObject('name', 'google-client-secret', 'keyVaultUrl', format('{0}secrets/google-client-secret', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))))), createArray()), if(parameters('hasMicrosoftAuth'), createArray(createObject('name', 'microsoft-client-id', 'keyVaultUrl', format('{0}secrets/microsoft-client-id', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))), createObject('name', 'microsoft-client-secret', 'keyVaultUrl', format('{0}secrets/microsoft-client-secret', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))))), createArray()))]",
+          "secrets": "[union(if(parameters('hasSubmissionTokenSecret'), createArray(createObject('name', 'submissiontoken-secret', 'keyVaultUrl', format('{0}secrets/submissiontoken-secret', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))))), createArray()), if(parameters('hasGoogleAuth'), createArray(createObject('name', 'google-client-id', 'keyVaultUrl', format('{0}secrets/google-client-id', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))), createObject('name', 'google-client-secret', 'keyVaultUrl', format('{0}secrets/google-client-secret', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))))), createArray()), if(parameters('hasMicrosoftAuth'), createArray(createObject('name', 'microsoft-client-id', 'keyVaultUrl', format('{0}secrets/microsoft-client-id', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))), createObject('name', 'microsoft-client-secret', 'keyVaultUrl', format('{0}secrets/microsoft-client-secret', reference(resourceId('Microsoft.KeyVault/vaults', variables('kvName')), '2024-04-01-preview').vaultUri), 'identity', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))))), createArray()))]",
           "registries": [
             {
               "server": "[reference(resourceId('Microsoft.ContainerRegistry/registries', take(variables('acrNameFinal'), 50)), '2023-11-01-preview').loginServer]",
-              "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))]"
+              "identity": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))]"
             }
           ]
         },
@@ -503,7 +500,7 @@
                 "cpu": "[json('0.5')]",
                 "memory": "1Gi"
               },
-              "env": "[union(createArray(createObject('name', 'Storage__PuzzlePath', 'value', '/data/puzzles'), createObject('name', 'Storage__LeaderboardPath', 'value', '/data/leaderboard'), createObject('name', 'SWEDISH_CROSSWORD_CACHE_PATH', 'value', '/data/cache'), createObject('name', 'ASPNETCORE_FORWARDEDHEADERS_ENABLED', 'value', 'true')), if(not(equals(if(parameters('deployDatabase'), format('Server=tcp:{0},1433;Database={1};Authentication=Active Directory Managed Identity;User Id={2};Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;ConnectRetryCount=10;ConnectRetryInterval=10;', reference(resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63)), '2023-08-01-preview').fullyQualifiedDomainName, variables('sqlDbName'), reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), '2023-01-31').clientId), ''), '')), createArray(createObject('name', 'ConnectionStrings__Leaderboard', 'value', if(parameters('deployDatabase'), format('Server=tcp:{0},1433;Database={1};Authentication=Active Directory Managed Identity;User Id={2};Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;ConnectRetryCount=10;ConnectRetryInterval=10;', reference(resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63)), '2023-08-01-preview').fullyQualifiedDomainName, variables('sqlDbName'), reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName'))), '2023-01-31').clientId), ''))), createArray()), if(parameters('hasSubmissionTokenSecret'), createArray(createObject('name', 'SubmissionToken__Secret', 'secretRef', 'submissiontoken-secret')), createArray()), if(parameters('hasGoogleAuth'), createArray(createObject('name', 'Authentication__Google__ClientId', 'secretRef', 'google-client-id'), createObject('name', 'Authentication__Google__ClientSecret', 'secretRef', 'google-client-secret')), createArray()), if(parameters('hasMicrosoftAuth'), createArray(createObject('name', 'Authentication__Microsoft__ClientId', 'secretRef', 'microsoft-client-id'), createObject('name', 'Authentication__Microsoft__ClientSecret', 'secretRef', 'microsoft-client-secret')), createArray()), variables('adminEnvVars'))]",
+              "env": "[union(createArray(createObject('name', 'Storage__PuzzlePath', 'value', '/data/puzzles'), createObject('name', 'Storage__LeaderboardPath', 'value', '/data/leaderboard'), createObject('name', 'SWEDISH_CROSSWORD_CACHE_PATH', 'value', '/data/cache'), createObject('name', 'ASPNETCORE_FORWARDEDHEADERS_ENABLED', 'value', 'true')), if(not(equals(if(parameters('deployDatabase'), format('Server=tcp:{0},1433;Database={1};Authentication=Active Directory Managed Identity;User Id={2};Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;ConnectRetryCount=10;ConnectRetryInterval=10;', reference(resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63)), '2023-08-01-preview').fullyQualifiedDomainName, variables('sqlDbName'), reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), '2023-01-31').clientId), ''), '')), createArray(createObject('name', 'ConnectionStrings__Leaderboard', 'value', if(parameters('deployDatabase'), format('Server=tcp:{0},1433;Database={1};Authentication=Active Directory Managed Identity;User Id={2};Encrypt=True;TrustServerCertificate=False;Connection Timeout=60;ConnectRetryCount=10;ConnectRetryInterval=10;', reference(resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63)), '2023-08-01-preview').fullyQualifiedDomainName, variables('sqlDbName'), reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id))), '2023-01-31').clientId), ''))), createArray()), if(parameters('hasSubmissionTokenSecret'), createArray(createObject('name', 'SubmissionToken__Secret', 'secretRef', 'submissiontoken-secret')), createArray()), if(parameters('hasGoogleAuth'), createArray(createObject('name', 'Authentication__Google__ClientId', 'secretRef', 'google-client-id'), createObject('name', 'Authentication__Google__ClientSecret', 'secretRef', 'google-client-secret')), createArray()), if(parameters('hasMicrosoftAuth'), createArray(createObject('name', 'Authentication__Microsoft__ClientId', 'secretRef', 'microsoft-client-id'), createObject('name', 'Authentication__Microsoft__ClientSecret', 'secretRef', 'microsoft-client-secret')), createArray()), variables('adminEnvVars'))]",
               "volumeMounts": [
                 {
                   "volumeName": "data",
@@ -530,7 +527,7 @@
         "[resourceId('Microsoft.ContainerRegistry/registries', take(variables('acrNameFinal'), 50))]",
         "[resourceId('Microsoft.App/managedEnvironments', format('{0}-env', parameters('appName')))]",
         "[resourceId('Microsoft.App/managedEnvironments/storages', format('{0}-env', parameters('appName')), 'crossworddata')]",
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity', parameters('appName')))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', format('{0}-identity-{1}', parameters('appName'), uniqueString(subscription().id)))]",
         "[resourceId('Microsoft.Sql/servers', take(variables('sqlServerName'), 63))]",
         "[resourceId('Microsoft.KeyVault/vaults', variables('kvName'))]"
       ]


### PR DESCRIPTION
Switches deployment from Azure SQL Free Limit (auto-pausing) to Standard S0 (DTU-based, always-on) for better user experience. Updates all references and documentation to remove auto-pause logic and clarify backup retention (35 days PITR, no LTR by default). Ensures managed identity names are unique per subscription. Improves Azure OIDC GitHub Actions workflow to skip login tests if required secrets are missing, preventing failures on external PRs.