### PR TITLE
Increase health check timeout; yield in warmup service

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -398,7 +398,7 @@ jobs:
       # 7. Verify deployment
       # ------------------------------------------------------------------
       - name: Verify Health
-        timeout-minutes: 3
+        timeout-minutes: 8
         run: |
           set -euo pipefail
           APP_URL="${{ steps.infra.outputs.app_url }}"
@@ -409,9 +409,9 @@ jobs:
 
           echo "🚀 Deployed to: $APP_URL"
 
-          MAX_ATTEMPTS=24
+          MAX_ATTEMPTS=84
           SLEEP_SECONDS=5
-          MAX_TOTAL_SECONDS=120
+          MAX_TOTAL_SECONDS=420
           START_TS=$(date +%s)
           READY_STATUS="000"
           LIVE_STATUS="000"

--- a/SwedishCrossword.Api/PuzzleWarmupService.cs
+++ b/SwedishCrossword.Api/PuzzleWarmupService.cs
@@ -150,6 +150,10 @@ sealed class PuzzleWarmupService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        // Yield once so host startup and health signaling are not delayed by
+        // the initial future-puzzle warmup run.
+        await Task.Yield();
+
         // On every startup regenerate future puzzles so they are rebuilt with the
         // latest generator code after each deployment.
         try


### PR DESCRIPTION
Extended health check duration in deploy-azure.yml to allow more time for app readiness after deployment. In
PuzzleWarmupService, added Task.Yield() at the start of ExecuteAsync to prevent startup delays from initial warmup.