### PR TITLE
Relax forwarded headers, remove HTTPS redirect, Bicep fixes

### DIFF
--- a/SwedishCrossword.Api/Program.cs
+++ b/SwedishCrossword.Api/Program.cs
@@ -93,7 +93,7 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
     options.ForwardLimit = 1;
-    options.RequireHeaderSymmetry = true;
+    options.RequireHeaderSymmetry = false;
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 
@@ -309,7 +309,6 @@ if (!app.Environment.IsDevelopment())
         ctx.Response.ContentType = "application/json";
         await ctx.Response.WriteAsync("{\"error\":\"An unexpected error occurred\"}");
     }));
-    app.UseHttpsRedirection();
 }
 
 static string GenerateCspNonce() => Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -324,7 +324,7 @@ resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = if (deployDataba
     publicNetworkAccess: 'Enabled'
     administrators: {
       administratorType: 'ActiveDirectory'
-      login: identity.properties.principalId
+      login: identity.name
       sid: identity.properties.principalId
       tenantId: tenant().tenantId
       principalType: 'Application'
@@ -553,7 +553,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               { name: 'Storage__PuzzlePath', value: '/data/puzzles' }
               { name: 'Storage__LeaderboardPath', value: '/data/leaderboard' }
               { name: 'SWEDISH_CROSSWORD_CACHE_PATH', value: '/data/cache' }
-              { name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED', value: 'true' }
             ],
             sqlConnectionString != '' ? [
               { name: 'ConnectionStrings__Leaderboard', value: sqlConnectionString }


### PR DESCRIPTION
- Set RequireHeaderSymmetry to false for forwarded headers
- Remove app.UseHttpsRedirection() in non-dev environments
- Use identity.name for SQL admin login in Bicep template
- Remove ASPNETCORE_FORWARDEDHEADERS_ENABLED env var