### PR TITLE
Add NODE_MAJOR build arg to Dockerfile for Node.js versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG NODE_MAJOR=24
 
 # --- Build stage -----------------------------------------------------------
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
+ARG NODE_MAJOR
 WORKDIR /src
 
 RUN apt-get update \


### PR DESCRIPTION
Added NODE_MAJOR as a build argument in the Dockerfile to allow specifying the major version of Node.js during the build process. This enhances flexibility in managing Node.js versions within the build environment.