### PR TITLE
Allow all hosts in production by setting AllowedHosts to "*"

### DIFF
--- a/SwedishCrossword.Api/appsettings.Production.json
+++ b/SwedishCrossword.Api/appsettings.Production.json
@@ -1,5 +1,5 @@
 {
-  "AllowedHosts": "svensktkorsord.se;www.svensktkorsord.se",
+  "AllowedHosts": "*",
   "ForwardedHeaders": {
     "TrustedProxies": [],
     "TrustedNetworks": []


### PR DESCRIPTION
Changed AllowedHosts in appsettings.Production.json from a restricted list of domains to "*", permitting requests from any host. ForwardedHeaders configuration remains unchanged.