### PR TITLE
Add configurable authentication cookie domain support

### DIFF
--- a/SwedishCrossword.Api.Tests/ApiIntegrationTests.cs
+++ b/SwedishCrossword.Api.Tests/ApiIntegrationTests.cs
@@ -1328,6 +1328,88 @@ public class ApiIntegrationTests : IAsyncDisposable
         var tz = TimeZoneInfo.FindSystemTimeZoneById("Europe/Stockholm");
         return DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz));
     }
+
+    // -----------------------------------------------------------------------
+    // External authentication (Google)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task GoogleLogin_UsesConfiguredPublicOriginInRedirectUri()
+    {
+        using var factory = Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Authentication:Google:ClientId", "test-google-client-id");
+            builder.UseSetting("Authentication:Google:ClientSecret", "test-google-client-secret");
+            builder.UseSetting("Authentication:PublicOrigin", "https://www.svensktkorsord.se");
+        });
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        var response = await client.GetAsync("/api/auth/login/google?returnUrl=%2Fapp%2Fprofile");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Redirect);
+        var redirectUri = new Uri(response.Headers.Location!.ToString(), UriKind.Absolute);
+        var query = QueryHelpers.ParseQuery(redirectUri.Query);
+        var callback = Uri.UnescapeDataString(query["redirect_uri"].ToString());
+        await Assert.That(callback).IsEqualTo("https://www.svensktkorsord.se/signin-google");
+    }
+
+    [Test]
+    public async Task GoogleLogin_WithCookieDomain_SetsCorrelationCookieDomain()
+    {
+        using var factory = Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Authentication:Google:ClientId", "test-google-client-id");
+            builder.UseSetting("Authentication:Google:ClientSecret", "test-google-client-secret");
+            builder.UseSetting("Authentication:CookieDomain", ".example.test");
+        });
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("https://www.example.test")
+        });
+
+        var response = await client.GetAsync("/api/auth/login/google?returnUrl=%2Fapp%2Fprofile");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Redirect);
+        var setCookie = response.Headers.GetValues("Set-Cookie").First(x => x.Contains(".AspNetCore.Correlation.", StringComparison.Ordinal));
+        await Assert.That(setCookie.Contains("domain=.example.test", StringComparison.OrdinalIgnoreCase)).IsTrue();
+    }
+
+    [Test]
+    public async Task GoogleLogin_WithoutPublicOrigin_UsesRequestOriginInRedirectUri()
+    {
+        using var factory = Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("Authentication:Google:ClientId", "test-google-client-id");
+            builder.UseSetting("Authentication:Google:ClientSecret", "test-google-client-secret");
+            builder.UseSetting("Authentication:PublicOrigin", string.Empty);
+        });
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("http://localhost")
+        });
+
+        var response = await client.GetAsync("/api/auth/login/google?returnUrl=%2Fapp%2Fprofile");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Redirect);
+        var redirectUri = new Uri(response.Headers.Location!.ToString(), UriKind.Absolute);
+        var query = QueryHelpers.ParseQuery(redirectUri.Query);
+        var callback = Uri.UnescapeDataString(query["redirect_uri"].ToString());
+        await Assert.That(callback).IsEqualTo("http://localhost/signin-google");
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal error handling
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public async Task UnknownRoute_ReturnsNotFound()
+    {
+        var response = await Client.GetAsync("/api/404");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+    }
 }
 
 file record PuzzleDateEntry(string Date, string[] Sizes);

--- a/SwedishCrossword.Api/Program.cs
+++ b/SwedishCrossword.Api/Program.cs
@@ -130,11 +130,16 @@ var authBuilder = builder.Services.AddAuthentication(options =>
     options.SlidingExpiration = true;
     // API endpoints: return 401 instead of redirect (ASP.NET Core 10 does this automatically for minimal APIs)
     options.LoginPath = null;
+
+    var authenticationCookieDomain = builder.Configuration["Authentication:CookieDomain"];
+    if (!string.IsNullOrWhiteSpace(authenticationCookieDomain))
+        options.Cookie.Domain = authenticationCookieDomain;
 });
 
 var googleClientId = builder.Configuration["Authentication:Google:ClientId"];
 var googleClientSecret = builder.Configuration["Authentication:Google:ClientSecret"];
 var authenticationPublicOrigin = builder.Configuration["Authentication:PublicOrigin"];
+var authenticationCookieDomain = builder.Configuration["Authentication:CookieDomain"];
 
 static string? BuildExternalRedirectUri(string? publicOrigin, PathString callbackPath)
 {
@@ -177,6 +182,10 @@ if (!string.IsNullOrEmpty(googleClientId) && !string.IsNullOrEmpty(googleClientS
         options.Scope.Clear();
         options.Scope.Add("openid");
         options.Scope.Add("profile");
+        options.CorrelationCookie.SameSite = SameSiteMode.None;
+        options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+        if (!string.IsNullOrWhiteSpace(authenticationCookieDomain))
+            options.CorrelationCookie.Domain = authenticationCookieDomain;
         options.Events.OnRedirectToAuthorizationEndpoint = context =>
         {
             context.Response.Redirect(RewriteRedirectUri(context.RedirectUri, authenticationPublicOrigin, options.CallbackPath));
@@ -193,6 +202,10 @@ if (!string.IsNullOrEmpty(microsoftClientId) && !string.IsNullOrEmpty(microsoftC
     {
         options.ClientId = microsoftClientId;
         options.ClientSecret = microsoftClientSecret;
+        options.CorrelationCookie.SameSite = SameSiteMode.None;
+        options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+        if (!string.IsNullOrWhiteSpace(authenticationCookieDomain))
+            options.CorrelationCookie.Domain = authenticationCookieDomain;
         options.Events.OnRedirectToAuthorizationEndpoint = context =>
         {
             context.Response.Redirect(RewriteRedirectUri(context.RedirectUri, authenticationPublicOrigin, options.CallbackPath));

--- a/SwedishCrossword.Api/appsettings.Production.json
+++ b/SwedishCrossword.Api/appsettings.Production.json
@@ -1,1 +1,1 @@
-{"AllowedHosts":"*","ForwardedHeaders":{"TrustedProxies":[],"TrustedNetworks":[]},"Authentication":{"PublicOrigin":"https://www.svensktkorsord.se"}}
+{"AllowedHosts":"*","ForwardedHeaders":{"TrustedProxies":[],"TrustedNetworks":[]},"Authentication":{"PublicOrigin":"https://www.svensktkorsord.se","CookieDomain":".svensktkorsord.se"}}

--- a/SwedishCrossword.Api/appsettings.json
+++ b/SwedishCrossword.Api/appsettings.json
@@ -21,6 +21,7 @@
   },
   "Authentication": {
     "PublicOrigin": "",
+    "CookieDomain": "",
     "Google": {
       "ClientId": "",
       "ClientSecret": ""


### PR DESCRIPTION
Support setting Authentication:CookieDomain for both main and correlation cookies, enabling cross-subdomain authentication. Applied to Google and Microsoft external logins with secure cookie settings. Added integration tests for cookie domain, redirect URI, and error handling. Updated appsettings files to include the new setting.