### PR TITLE
Fix friends challenge reader crash

### DIFF
--- a/SwedishCrossword.Api.Tests/ApiIntegrationTests.cs
+++ b/SwedishCrossword.Api.Tests/ApiIntegrationTests.cs
@@ -1236,6 +1236,41 @@ public class ApiIntegrationTests : IAsyncDisposable
     }
 
     [Test]
+    public async Task FriendsChallenges_List_WithChallengeData_ReturnsOk()
+    {
+        await using var authFixture = new ApiTestFixture(enableTestAuth: true);
+        var profileStore = authFixture.Factory.Services.GetRequiredService<IUserProfileStore>();
+        var friendStore = authFixture.Factory.Services.GetRequiredService<IFriendStore>();
+        var historyStore = authFixture.Factory.Services.GetRequiredService<IHistoryStore>();
+
+        var me = await authFixture.Client.GetFromJsonAsync<JsonElement>("/api/auth/me");
+        var senderUser = me.GetProperty("userId").GetString()!;
+        var friendUser = await profileStore.ResolveCanonicalUserIdAsync("friend-user-2", null);
+        await profileStore.SetAliasAsync(senderUser, "JockeB");
+        await profileStore.SetAliasAsync(friendUser, "Bob");
+
+        var (sent, _) = await friendStore.SendFriendRequestAsync(senderUser, friendUser);
+        await Assert.That(sent).IsTrue();
+        var requests = await friendStore.GetPendingRequestsAsync(friendUser);
+        await friendStore.AcceptFriendRequestAsync(requests[0].Id, friendUser);
+
+        var friendshipId = (await friendStore.GetFriendsAsync(senderUser))[0].FriendId;
+        var date = GetSwedishDate().ToString("yyyy-MM-dd");
+        var (created, _) = await friendStore.CreateChallengeAsync(senderUser, friendshipId, date, "17x17");
+        await Assert.That(created).IsTrue();
+
+        await historyStore.AppendHistoryAsync(date, new HistoryRecord("JockeB", 240.0, 1000L, "h1", "17x17", 0, 0, senderUser));
+        await historyStore.AppendHistoryAsync(date, new HistoryRecord("Bob", 300.0, 1001L, "h1", "17x17", 1, 0, friendUser));
+
+        var response = await authFixture.Client.GetAsync("/api/friends/challenges");
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
+        await Assert.That(payload.ValueKind).IsEqualTo(JsonValueKind.Array);
+        await Assert.That(payload.GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task FriendsChallenges_Create_Unauthenticated_ReturnsUnauthorized()
     {
         var response = await Client.PostAsJsonAsync("/api/friends/challenges", new

--- a/SwedishCrossword.Api/LeaderboardStore.cs
+++ b/SwedishCrossword.Api/LeaderboardStore.cs
@@ -1466,23 +1466,28 @@ sealed partial class LeaderboardStore : IScoreStore, IHistoryStore, IUserProfile
         AddParam(cmd, "@uid", userId);
 
         var pending = new List<(string Id, string FriendAlias, string Date, string PuzzleSize, string Status, string Direction, long CreatedAt, long? RespondedAt, string FromUserId, string ToUserId, string CurrentUserAlias, string FriendUserAlias)>();
-        await using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        await using (var reader = await cmd.ExecuteReaderAsync())
         {
-            pending.Add((
-                Id: reader.GetString(0),
-                FriendAlias: reader.IsDBNull(1) ? "Okänd" : reader.GetString(1),
-                Date: reader.GetString(2),
-                PuzzleSize: reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
-                Status: reader.GetString(4),
-                Direction: reader.GetString(5),
-                CreatedAt: reader.GetInt64(6),
-                RespondedAt: reader.IsDBNull(7) ? null : reader.GetInt64(7),
-                FromUserId: reader.GetString(8),
-                ToUserId: reader.GetString(9),
-                CurrentUserAlias: reader.GetString(reader.GetString(5) == "incoming" ? 11 : 10),
-                FriendUserAlias: reader.GetString(reader.GetString(5) == "incoming" ? 10 : 11)
-            ));
+            while (await reader.ReadAsync())
+            {
+                var direction = reader.GetString(5);
+                var fromAlias = reader.IsDBNull(10) ? "Okänd" : reader.GetString(10);
+                var toAlias = reader.IsDBNull(11) ? "Okänd" : reader.GetString(11);
+                pending.Add((
+                    Id: reader.GetString(0),
+                    FriendAlias: reader.IsDBNull(1) ? "Okänd" : reader.GetString(1),
+                    Date: reader.GetString(2),
+                    PuzzleSize: reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+                    Status: reader.GetString(4),
+                    Direction: direction,
+                    CreatedAt: reader.GetInt64(6),
+                    RespondedAt: reader.IsDBNull(7) ? null : reader.GetInt64(7),
+                    FromUserId: reader.GetString(8),
+                    ToUserId: reader.GetString(9),
+                    CurrentUserAlias: direction == "incoming" ? toAlias : fromAlias,
+                    FriendUserAlias: direction == "incoming" ? fromAlias : toAlias
+                ));
+            }
         }
 
         var solveMap = await LoadChallengeSolveMapAsync(conn, userId, pending);


### PR DESCRIPTION
- close the challenge DataReader before querying solve history
- handle the /api/friends/challenges read path safely
- add integration coverage for challenge list with real challenge data