### PR TITLE
Switch workflows to use default GitHub Actions token

### DIFF
--- a/.github/workflows/format-pr-apply.yml
+++ b/.github/workflows/format-pr-apply.yml
@@ -35,7 +35,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           pattern: dependabot-format-*
           path: .download
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ github.token }}
         continue-on-error: true
 
       - name: Locate artifact root
@@ -55,7 +55,7 @@ jobs:
         id: meta
         if: steps.locate.outputs.artifact_root != ''
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           REPO: ${{ github.repository }}
           RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -78,18 +78,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
           persist-credentials: false
 
       - name: Setup .NET


### PR DESCRIPTION
Replaced custom GitHub App token usage with the default github.token for artifact download, metadata validation, and PR branch checkout steps in workflow files. This simplifies authentication and reduces dependency on custom secrets.