### PR TITLE
Update commit logic in format workflows for accuracy

### DIFF
--- a/.github/workflows/format-pr-apply.yml
+++ b/.github/workflows/format-pr-apply.yml
@@ -148,6 +148,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "github-actions"
           git add -A
+          if git diff --cached --quiet; then
+            echo "No commit needed after staging."
+            exit 0
+          fi
+
           git commit -m "style: auto-format code with dotnet format"
           git push "https://x-access-token:${APP_TOKEN}@github.com/$REPO.git" "HEAD:$HEAD_REF"
 

--- a/.github/workflows/format-pr.yml
+++ b/.github/workflows/format-pr.yml
@@ -63,14 +63,14 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "github-actions"
 
-          if [ -n "$(git status --porcelain)" ]; then
-            git add -A
-            git commit -m "style: auto-format code with dotnet format"
-            git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"
-          else
+          git add -A
+          if git diff --cached --quiet; then
             echo "No formatting changes needed"
+            exit 0
           fi
 
+          git commit -m "style: auto-format code with dotnet format"
+          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" "HEAD:${{ github.event.pull_request.head.ref }}"
   prepare-dependabot-format-patch:
     name: Prepare Dependabot format patch
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Refactor GitHub Actions to always stage changes before checking for diffs, using git diff --cached --quiet to determine if a commit is needed. This prevents unnecessary commits and pushes when no formatting changes are present.