### PR TITLE
Add dynamic guides/lexicon sitemap entries & index script

### DIFF
--- a/SwedishCrossword.Api.Tests/ApiIntegrationTests.cs
+++ b/SwedishCrossword.Api.Tests/ApiIntegrationTests.cs
@@ -99,9 +99,29 @@ public class ApiIntegrationTests : IDisposable
         await Assert.That(content).Contains("https://www.svensktkorsord.se/puzzle");
         await Assert.That(content).Contains("https://www.svensktkorsord.se/leaderboard");
         await Assert.That(content).Contains("https://www.svensktkorsord.se/calendar");
+        await Assert.That(content).Contains("https://www.svensktkorsord.se/guides");
+        await Assert.That(content).Contains("https://www.svensktkorsord.se/lexicon");
         await Assert.That(content).Contains("https://www.svensktkorsord.se/about");
         await Assert.That(content).Contains("https://www.svensktkorsord.se/contact");
         await Assert.That(content).Contains("https://www.svensktkorsord.se/privacy-policy");
+    }
+
+    [Test]
+    public async Task Sitemap_IncludesGuideArticlePages()
+    {
+        var response = await Client.GetAsync("/sitemap.xml");
+        var content = await response.Content.ReadAsStringAsync();
+
+        await Assert.That(content).Contains("https://www.svensktkorsord.se/guides/guide-losa-svenska-korsord");
+    }
+
+    [Test]
+    public async Task Sitemap_IncludesLexiconArticlePages()
+    {
+        var response = await Client.GetAsync("/sitemap.xml");
+        var content = await response.Content.ReadAsStringAsync();
+
+        await Assert.That(content).Contains("https://www.svensktkorsord.se/lexicon/lexikon-ess");
     }
 
     [Test]

--- a/SwedishCrossword.Api/Endpoints/SitemapEndpoints.cs
+++ b/SwedishCrossword.Api/Endpoints/SitemapEndpoints.cs
@@ -1,16 +1,19 @@
 ﻿using System.Globalization;
 using System.Text;
+using System.Text.Json;
 
 namespace SwedishCrossword.Api.Endpoints;
 
 internal static class SitemapEndpoints
 {
+    private const string SiteBaseUrl = "https://www.svensktkorsord.se";
+
     internal static WebApplication MapSitemapEndpoints(this WebApplication app)
     {
-        app.MapGet("/sitemap.xml", (PuzzleDateIndex dateIndex, TimeProvider timeProvider, HttpContext ctx) =>
+        app.MapGet("/sitemap.xml", (PuzzleDateIndex dateIndex, TimeProvider timeProvider, IWebHostEnvironment env, HttpContext ctx) =>
         {
             var today = timeProvider.GetSwedishDate();
-            var xml = GenerateSitemap(dateIndex, today);
+            var xml = GenerateSitemap(dateIndex, env.WebRootPath, today);
 
             // Set cache headers explicitly (24 hours)
             ctx.Response.Headers.CacheControl = "public, max-age=86400";
@@ -23,8 +26,11 @@ internal static class SitemapEndpoints
         return app;
     }
 
-    private static string GenerateSitemap(PuzzleDateIndex dateIndex, DateOnly today)
+    private static string GenerateSitemap(PuzzleDateIndex dateIndex, string webRootPath, DateOnly today)
     {
+        ArgumentNullException.ThrowIfNull(dateIndex);
+        ArgumentException.ThrowIfNullOrWhiteSpace(webRootPath);
+
         var sb = new StringBuilder();
         sb.AppendLine("""<?xml version="1.0" encoding="UTF-8"?>""");
         sb.AppendLine("""<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""");
@@ -37,6 +43,8 @@ internal static class SitemapEndpoints
             new { path = "/puzzle", changefreq = "daily", priority = 0.9 },
             new { path = "/leaderboard", changefreq = "hourly", priority = 0.8 },
             new { path = "/calendar", changefreq = "daily", priority = 0.85 },
+            new { path = "/guides", changefreq = "weekly", priority = 0.8 },
+            new { path = "/lexicon", changefreq = "daily", priority = 0.85 },
             new { path = "/about", changefreq = "monthly", priority = 0.7 },
             new { path = "/contact", changefreq = "monthly", priority = 0.6 },
             new { path = "/privacy-policy", changefreq = "yearly", priority = 0.3 },
@@ -47,6 +55,16 @@ internal static class SitemapEndpoints
         foreach (var page in staticPages)
         {
             AddUrlEntry(sb, page.path, todayStr, page.changefreq, page.priority);
+        }
+
+        foreach (var guideEntry in LoadGuideEntries(webRootPath))
+        {
+            AddUrlEntry(sb, $"/guides/{guideEntry.Slug}", guideEntry.LastModified, "monthly", 0.7);
+        }
+
+        foreach (var lexiconSlug in LoadLexiconSlugs(webRootPath))
+        {
+            AddUrlEntry(sb, $"/lexicon/{lexiconSlug}", todayStr, "weekly", 0.7);
         }
 
         // Dynamic puzzle archive dates
@@ -64,10 +82,127 @@ internal static class SitemapEndpoints
     private static void AddUrlEntry(StringBuilder sb, string path, string lastmod, string changefreq, double priority)
     {
         sb.AppendLine(CultureInfo.InvariantCulture, $"  <url>");
-        sb.AppendLine(CultureInfo.InvariantCulture, $"    <loc>https://www.svensktkorsord.se{path}</loc>");
+        sb.AppendLine(CultureInfo.InvariantCulture, $"    <loc>{SiteBaseUrl}{path}</loc>");
         sb.AppendLine(CultureInfo.InvariantCulture, $"    <lastmod>{lastmod}</lastmod>");
         sb.AppendLine(CultureInfo.InvariantCulture, $"    <changefreq>{changefreq}</changefreq>");
         sb.AppendLine(CultureInfo.InvariantCulture, $"    <priority>{priority.ToString("F1", CultureInfo.InvariantCulture)}</priority>");
         sb.AppendLine(CultureInfo.InvariantCulture, $"  </url>");
     }
+
+    private static IReadOnlyList<SitemapGuideEntry> LoadGuideEntries(string webRootPath)
+    {
+        var path = Path.Combine(webRootPath, "app", "guides", "index.json");
+        if (!File.Exists(path))
+        {
+            return [];
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var json = JsonDocument.Parse(stream);
+
+            if (!json.RootElement.TryGetProperty("entries", out var entries) || entries.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var result = new List<SitemapGuideEntry>();
+            foreach (var entry in entries.EnumerateArray())
+            {
+                var slug = entry.TryGetProperty("slug", out var slugElement)
+                    ? slugElement.GetString()
+                    : null;
+
+                if (string.IsNullOrWhiteSpace(slug))
+                {
+                    continue;
+                }
+
+                var published = entry.TryGetProperty("published", out var publishedElement)
+                    ? publishedElement.GetString()
+                    : null;
+
+                var lastModified = DateOnly.TryParseExact(
+                        published,
+                        "yyyy-MM-dd",
+                        CultureInfo.InvariantCulture,
+                        DateTimeStyles.None,
+                        out var publishedDate)
+                    ? publishedDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+                    : DateOnly.FromDateTime(File.GetLastWriteTimeUtc(path)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+                result.Add(new SitemapGuideEntry(slug, lastModified));
+            }
+
+            return result;
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static IReadOnlyList<string> LoadLexiconSlugs(string webRootPath)
+    {
+        var path = Path.Combine(webRootPath, "app", "lexicon-data", "index.json");
+        if (!File.Exists(path))
+        {
+            return [];
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var json = JsonDocument.Parse(stream);
+
+            if (!json.RootElement.TryGetProperty("entries", out var entries) || entries.ValueKind != JsonValueKind.Array)
+            {
+                return [];
+            }
+
+            var slugs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in entries.EnumerateArray())
+            {
+                if (!entry.TryGetProperty("slug", out var slugElement))
+                {
+                    continue;
+                }
+
+                var slug = slugElement.GetString();
+                if (string.IsNullOrWhiteSpace(slug))
+                {
+                    continue;
+                }
+
+                slugs.Add(slug);
+            }
+
+            return slugs.Count > 0
+                ? [.. slugs.OrderBy(value => value, StringComparer.Ordinal)]
+                : [];
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private sealed record SitemapGuideEntry(string Slug, string LastModified);
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
+    "build": "node ../scripts/generate-guides-index.mjs && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
     "test": "vitest run",
     "preview": "vite preview",
     "lexicon:preview": "pwsh -NoProfile -File ../scripts/generate-lexicon-content.ps1 -Preview -TotalCount 20000 -CoreCount 3000 -MaxWordLength 12",

--- a/frontend/public/guides/index.json
+++ b/frontend/public/guides/index.json
@@ -1,0 +1,9 @@
+{
+  "generatedAt": "2026-07-29T08:03:54.519Z",
+  "entries": [
+    {
+      "slug": "guide-losa-svenska-korsord",
+      "published": "2026-07-01"
+    }
+  ]
+}

--- a/scripts/generate-guides-index.mjs
+++ b/scripts/generate-guides-index.mjs
@@ -1,0 +1,70 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const guidesSourceDir = path.join(repoRoot, 'frontend', 'src', 'content', 'guides');
+const guidesOutputDir = path.join(repoRoot, 'frontend', 'public', 'guides');
+const guidesOutputPath = path.join(guidesOutputDir, 'index.json');
+
+function parseFrontMatter(markdown) {
+  const match = markdown.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n?/);
+  if (!match) {
+    throw new Error('Guide markdown file is missing valid front matter.');
+  }
+
+  const map = new Map();
+  for (const line of match[1].split(/\r?\n/)) {
+    const separatorIndex = line.indexOf(':');
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim().replace(/^"|"$/g, '');
+    map.set(key, value);
+  }
+
+  const slug = map.get('slug') ?? '';
+  if (!slug) {
+    throw new Error('Guide markdown file front matter is missing slug.');
+  }
+
+  const published = map.get('published') ?? '';
+  return { slug, published };
+}
+
+async function generateGuidesIndex() {
+  const files = await readdir(guidesSourceDir);
+  const markdownFiles = files
+    .filter(file => file.toLowerCase().endsWith('.md'))
+    .sort((left, right) => left.localeCompare(right, 'sv-SE'));
+
+  const entries = [];
+  for (const file of markdownFiles) {
+    const fullPath = path.join(guidesSourceDir, file);
+    const raw = await readFile(fullPath, 'utf8');
+    entries.push(parseFrontMatter(raw));
+  }
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    entries,
+  };
+
+  await mkdir(guidesOutputDir, { recursive: true });
+
+  const json = `${JSON.stringify(payload, null, 2)}\n`.replace(/\n/g, '\r\n');
+  await writeFile(guidesOutputPath, json, 'utf8');
+
+  // eslint-disable-next-line no-console
+  console.log(`Generated ${guidesOutputPath} with ${entries.length} guide entries.`);
+}
+
+generateGuidesIndex().catch(error => {
+  // eslint-disable-next-line no-console
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
- Add sitemap entries for /guides and /lexicon sections
- Dynamically include guide and lexicon articles by reading index.json files
- Implement helpers in SitemapEndpoints.cs to load entries from JSON
- Add integration tests for guide/lexicon URLs in sitemap
- Add generate-guides-index.mjs to build guides index from Markdown
- Update frontend build to run guide index generator pre-build
- Add sample guides index.json with test entry
- Ensure all sitemap URLs use site base URL constant